### PR TITLE
Add private folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+private/


### PR DESCRIPTION
Create a private folder at root level to store apiKey.js which will export the key by default.